### PR TITLE
sctp: implement encode for SCTP Authenticated Chunks

### DIFF
--- a/lib/Pz/Makefile
+++ b/lib/Pz/Makefile
@@ -4,7 +4,7 @@ OBJS =	DmObject.o ItPosition.o McAH.o McARP.o McAlgorithm.o	\
 	McICMPv6.o McIGMP.o McIKE.o McIPv4.o McIPv6.o McInit.o	\
 	McMLDv2.o McMobility.o McNoNext.o McNull.o McObject.o	\
 	McRIPng.o McRR.o McSIP.o McSNMP.o McSub.o McTCP.o	\
-	McSCTP.o MmSCTPChecksum.o	\
+	McSCTP.o MmSCTPChecksum.o MmSCTPAuth.o	\
 	McUDP.o McVRRP.o MfAlgorithm.o MmChecksum.o MmData.o	\
 	MmHeader.o MmObject.o MvArgCheck.o MvFunction.o		\
 	PAlgorithm.o PControl.o PObject.o PcObject.o PlObject.o	\

--- a/lib/Pz/McSCTP.cc
+++ b/lib/Pz/McSCTP.cc
@@ -35,6 +35,7 @@
 
 #include "McSCTP.h"
 #include "MmSCTPChecksum.h"
+#include "MmSCTPAuth.h"
 #include "MmData.h"
 #include "ItPosition.h"
 #include "WObject.h"
@@ -98,7 +99,10 @@ bool McUpp_SCTP::generate(WControl& c,WObject* w_self,OCTBUF& buf) const {
 	bool rtn = SUPER::generate(c, w_self, buf);
 	if(!c.error()){
 		Con_IPinfo* info = c.IPinfo();
-		if(info)info->generate_postUppChecksum(c, buf, w_self);
+		if(info) {
+			info->generate_postSCTPAuth(c, buf, w_self);
+			info->generate_postUppChecksum(c, buf, w_self);
+		}
 	}
 	return rtn;
 }
@@ -917,8 +921,7 @@ McAuthenticationChunk* McAuthenticationChunk::create(CSTR key){
 	mc->common_member();
 	mc->member(new MmUint("SharedKeyIdentifier", 16, UN(0), UN(0)));
 	mc->member(new MmUint("HMACIdentifier", 16, UN(0), UN(0)));
-	mc->member(new MmData("HMAC"));
-	mc->member(new MmData("Padding", DEF_EVALSKIP));
+	mc->member(new MmSCTPAuth("HMAC"));
 
 	MmChunk::add(mc);
 	return mc;

--- a/lib/Pz/MmSCTPAuth.cc
+++ b/lib/Pz/MmSCTPAuth.cc
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2008, 2009 Fujitsu Limited.
+ * All rights reserved.
+ *
+ * Redistribution and use of this software in source and binary forms, with
+ * or without modification, are permitted provided that the following
+ * conditions and disclaimer are agreed and accepted by the user:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the names of the copyrighters, the name of the project which
+ * is related to this software (hereinafter referred to as "project") nor
+ * the names of the contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * 4. No merchantable use may be permitted without prior written
+ * notification to the copyrighters. However, using this software for the
+ * purpose of testing or evaluating any products including merchantable
+ * products may be permitted without any notification to the copyrighters.
+ *
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHTERS, THE PROJECT AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING
+ * BUT NOT LIMITED THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE, ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHTERS, THE PROJECT OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT,STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *    Author: Wei Yongjun <yjwei@cn.fujitsu.com>
+ *
+ */
+#include "MmSCTPAuth.h"
+#include "PControl.h"
+#include "RObject.h"
+#include "WObject.h"
+#include "PvObject.h"
+#include "PvOctets.h"
+#include "CmMain.h"
+#include <stdio.h>
+#include <string.h>
+
+//////////////////////////////////////////////////////////////////////////////
+MmSCTPAuth::MmSCTPAuth(CSTR key, bool evalskip):MmObject(key), evalskip_(evalskip){}
+MmSCTPAuth::~MmSCTPAuth() {}
+
+int32_t MmSCTPAuth::token() const{
+	return metaToken(tkn_data_);
+}
+
+uint32_t MmSCTPAuth::objectLength(const PObject* o, const WObject* w) const {
+	return o != 0 ? o->objectLength(w) : 0;
+}
+
+bool MmSCTPAuth::encodeOctets(WControl&, const ItPosition& at,
+				OCTBUF& dst, const PvOctets& elm) const {
+	dst.encode(at, elm);
+	return true;
+}
+
+uint32_t MmSCTPAuth::length_for_reverse(
+		RControl&, ItPosition& at, OCTBUF& buf) const {
+	return buf.remainLength(at.bytes());
+}
+
+RObject* MmSCTPAuth::reverse(RControl& c,
+		RObject* r_parent, ItPosition& at, OCTBUF& buf) const {
+	const MObject* m_parent = r_parent ? r_parent->meta() : 0;
+	uint32_t length = length_for_reverse(c,at,buf);
+	if(evalskip_ && !length)
+		return 0;	//useless reverse
+	ItPosition size(length, 0);
+	if(!check_decode_limit(m_parent, at, buf, size)){
+		c.set_error(1);
+		return 0;
+	}
+	PvObject* pv = buf.substr(at.bytes(), length);
+	RObject* r_self = reverseRm(c, r_parent, at, size, pv);
+	at += size;
+	return r_self;
+}
+
+void MmSCTPAuth::composeList(WControl& c,
+		WObject* w_parent, const PObjectList& pls) const {
+	const PObject* pl =
+		pls.reverseMatching(this, (PObjectEqFunc)&PObject::isEqualMeta);
+	pl ? pl->selfCompose(c, w_parent) : compose(c, w_parent, 0);
+}
+
+WObject* MmSCTPAuth::compose(WControl& c,
+		WObject* w_parent, const PObject* pl) const {
+	const TypevsMcDict* keep = c.dict();
+	c.dict_set(0);
+	WObject* wm = composeWm(c, w_parent, pl);
+	c.dict_set(keep);
+	return wm;
+}
+
+WObject* MmSCTPAuth::composeWm(WControl&,
+		WObject* w_parent, const PObject* pl)const{
+	return new WmSCTPAuth(w_parent, this, pl);
+}
+
+RObject* MmSCTPAuth::reverseRm(RControl&,RObject* r_parent,
+		const ItPosition& at,const ItPosition& size,PvObject* pv)const {
+	return new RmObject(r_parent, this, at, size, pv);
+}
+
+bool MmSCTPAuth::generate(WControl& c,WObject* w_self,OCTBUF& buf) const {
+	bool rtn = MmObject::generate(c, w_self, buf);
+	if(!c.error()) {
+		Con_IPinfo *info = c.IPinfo();
+		const PObject* pl = w_self->object();
+		if(info && pl->rvalue() && !strcmp("sctpauth", pl->rvalue()->metaString())) {
+			info->postSCTPAuth(w_self);
+		}
+	}
+
+        return(rtn);
+}
+
+////////////////////////////////////////////////////////////////
+PfSCTPAuth::PfSCTPAuth(const MfSCTPAuth *a, CSTR b, int c): PvFunction(a, b, c), meta_(a), context_(0) {}
+PfSCTPAuth::~PfSCTPAuth() {};
+
+const MObject *PfSCTPAuth::meta() const {
+	return(metaClass());
+}
+
+void PfSCTPAuth::init() {
+	const MfSCTPAuth *m = metaClass();
+
+	if (m)
+		context_ = m->init(context_, args());
+}
+
+void PfSCTPAuth::update(const OCTBUF &s) {
+	const MfSCTPAuth *m = metaClass();
+
+	if (m)
+		m->update(context_, args(), s);
+}
+
+PvOctets *PfSCTPAuth::result() {
+	const MfSCTPAuth *m = metaClass();
+
+	if (m)
+		return m->result(context_, args());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+#define SUPER	WmObject
+WmSCTPAuth::WmSCTPAuth(WObject* p, const MObject* m, const PObject* po) : SUPER(p, m, po) {}
+WmSCTPAuth::~WmSCTPAuth() {}
+
+void WmSCTPAuth::post_generate(Con_IPinfo& info, WControl& c, OCTBUF& buf,
+		WObject* base) {
+	const OCTBUF *basebuf = (const OCTBUF *)base->pvalue();
+	PfSCTPAuth *pf_auth = (PfSCTPAuth *)(object()->rvalue());
+	WObject *w_auth = (WObject *)info.postSCTPAuth();
+	uint32_t length, offset;
+	OCTBUF *calc = 0;
+
+	if(!w_auth || !pf_auth)
+		return;
+
+	offset = w_auth->offset().bytes() - base->offset().bytes() - 8;
+	length = base->size().bytes() - offset;
+
+	OCTBUF hmacbuf(length, (OCTSTR)basebuf->string() + offset, true);
+
+	if(pf_auth) {
+		pf_auth->init();
+		pf_auth->update(hmacbuf);
+		calc = pf_auth->result();
+	}
+
+	if(calc) {
+		set_rgenerate(calc);
+		SUPER::generate(c, buf);
+	}
+}
+
+bool WmSCTPAuth::doEvaluate(WControl& c,RObject& r) {
+	RmObject& rm = (RmObject &)r;
+	const PvObject* ro = rm.pvalue();
+	const PvObject* eo = revaluate();
+	if (!eo) eo = ro;
+	return valueEvaluate(c, ro, eo);
+}
+
+#undef SUPER

--- a/lib/Pz/MmSCTPAuth.h
+++ b/lib/Pz/MmSCTPAuth.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2008, 2009 Fujitsu Limited.
+ * All rights reserved.
+ *
+ * Redistribution and use of this software in source and binary forms, with
+ * or without modification, are permitted provided that the following
+ * conditions and disclaimer are agreed and accepted by the user:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the names of the copyrighters, the name of the project which
+ * is related to this software (hereinafter referred to as "project") nor
+ * the names of the contributors may be used to endorse or promote products
+ * derived from this software without specific prior written permission.
+ *
+ * 4. No merchantable use may be permitted without prior written
+ * notification to the copyrighters. However, using this software for the
+ * purpose of testing or evaluating any products including merchantable
+ * products may be permitted without any notification to the copyrighters.
+ *
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHTERS, THE PROJECT AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING
+ * BUT NOT LIMITED THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE, ARE DISCLAIMED.  IN NO EVENT SHALL THE
+ * COPYRIGHTERS, THE PROJECT OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT,STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *    Author: Wei Yongjun <yjwei@cn.fujitsu.com>
+ *
+ */
+
+#if !defined(__MmSCTPAuth_h__)
+#define __MmSCTPAuth_h__
+
+#include "MmObject.h"
+#include "RObject.h"
+#include "WObject.h"
+#include "PvOctets.h"
+#include "MvFunction.h"
+
+///////////////////////////////////////////////////////////////////////////////
+class MmSCTPAuth : public MmObject {
+	bool	evalskip_;
+public:
+	MmSCTPAuth(CSTR, bool evalskip=false);
+virtual ~MmSCTPAuth();
+	int32_t token() const;
+public:
+// COMPOSE/REVERSE INTERFACE --------------------------------------------------
+virtual bool encodeOctets(WControl&, const ItPosition&, OCTBUF&, const PvOctets&)const;
+virtual uint32_t objectLength(const PObject*, const WObject* =0) const;
+// COMPOSE/REVERSE INTERFACE --------------------------------------------------
+virtual WObject* compose(WControl&,WObject* w_parent,const PObject* pl)const;
+virtual RObject* reverse(RControl&,RObject* r_parent,ItPosition&,OCTBUF&) const;
+// COMPOSE/REVERSE INTERFACE --------------------------------------------------
+virtual void composeList(WControl&, WObject* w_parent, const PObjectList& pls)const;
+virtual uint32_t length_for_reverse(RControl&,ItPosition& at,OCTBUF& buf)const;
+//virtual PvObject *reversePv(RControl &, const ItPosition &, const ItPosition &, const OCTBUF &) const;
+virtual RObject* reverseRm(RControl &, RObject *, const ItPosition &, const ItPosition &, PvObject *) const;
+virtual WObject* composeWm(WControl &, WObject *, const PObject *) const;
+virtual bool generate(WControl &, WObject *, OCTBUF &) const;
+virtual bool disused() const {return evalskip_;}
+};
+
+////////////////////////////////////////////////////////////////
+class PfSCTPAuth: public PvFunction {
+private:
+	const MfSCTPAuth *meta_;
+	OCTSTR context_;
+public:
+	PfSCTPAuth(const MfSCTPAuth *, CSTR, int);
+	virtual ~PfSCTPAuth();
+	const MfSCTPAuth *metaClass() const;
+	virtual const MObject *meta() const;
+	void init();
+	void update(const OCTBUF &);
+	PvOctets *result();
+};
+
+inline const MfSCTPAuth *PfSCTPAuth::metaClass() const {
+	return (meta_);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+class WmSCTPAuth : public WmObject {
+public:
+	WmSCTPAuth(WObject* p, const MObject* m, const PObject* po);
+virtual ~WmSCTPAuth();
+virtual void post_generate(Con_IPinfo&, WControl&, OCTBUF& buf, WObject* from);
+virtual bool doEvaluate(WControl& c, RObject& r);
+};
+
+#endif

--- a/lib/Pz/MvArgCheck.cc
+++ b/lib/Pz/MvArgCheck.cc
@@ -579,6 +579,51 @@ bool MfDHCPAuth::checkArgument(const PFunction &o, const PObjectList &a) const {
 }
 
 //======================================================================
+// sctpauth(algo, hexstr);
+
+bool MfSCTPAuth::checkArgument(const PFunction &o, const PObjectList &a) const {
+	bool ok = true;
+	bool rc = true;
+	CSTR name = o.metaString();
+
+	uint32_t n = a.size();
+	if (n != 2) {
+		o.error("E %s must have 2 argument, not %d", name, n);
+		return(false);
+	}
+
+	CSTR a0 = a[0]->strValue(ok);
+	if (!ok) {
+		o.error("E %s first argument has to be string", name);
+		return(false);
+	} else {
+		if (strcmp(a0, "sha1")
+#if defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER >= 0x0090800fL)
+		&& strcmp(a0, "sha256")
+#endif
+		) {
+			o.error("E %s unknown algorithm -- %s", name, a0);
+			return(false);
+	}
+	}
+
+	CSTR a1 = a[1]->strValue(ok);
+	if (!ok) {
+		o.error("E %s second argument has to be string", name);
+		rc = false;
+	} else {
+		uint32_t a1len = a[1]->length();
+
+		if (!isHexStr(a1, a1len)) {
+			o.error("E %s argument has to be hex characters", name);
+			rc = false;
+		}
+	}
+
+	return(rc);
+}
+
+//======================================================================
 // substr(var,int,int)
 bool MvSubstr::checkArgument(const PFunction& o,const PObjectList& a) const {
 	bool ok=true;

--- a/lib/Pz/MvFunction.cc
+++ b/lib/Pz/MvFunction.cc
@@ -51,6 +51,7 @@
 #include "PControl.h"
 #include "McMobility.h"
 #include "McDHCPv6.h"
+#include "MmSCTPAuth.h"
 #include "McDNS.h"
 #include "McSIP.h"
 #include "McSNMP.h"
@@ -1155,6 +1156,136 @@ PObject *MfDHCPAuth::tokenObject(int l, CSTR f) const {
 	return(new PfDHCPAuth(this, f, l));
 }
 #undef DHCP_HMAC_MD5
+
+//======================================================================
+#define SCTP_SHA1_SIG_SIZE 20
+#define SCTP_SHA256_SIG_SIZE 32
+
+uint32_t MfSCTPAuth::length_ = SCTP_SHA1_SIG_SIZE;
+
+MfSCTPAuth::MfSCTPAuth(CSTR s): MvOctets(s) {}
+MfSCTPAuth::~MfSCTPAuth() {}
+
+uint32_t MfSCTPAuth::functionLength(const PObjectList &a, const WObject *) const {
+	bool ok = true;
+	CSTR a0 = a[0]->strValue(ok);
+
+	length_ = SCTP_SHA1_SIG_SIZE;
+
+	if (ok) {
+		if (!strcmp(a0, "sha1")) {
+			length_ = SCTP_SHA1_SIG_SIZE;
+#if defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER >= 0x0090800fL)
+		} else if (!strcmp(a0, "sha256")) {
+			length_ = SCTP_SHA256_SIG_SIZE;
+#endif
+		}
+	}
+
+	return length_;
+}
+
+bool MfSCTPAuth::generateOctetsWith(const PObjectList &a, PvOctets &oct, WObject *) const {
+	oct.set(length_);
+	memset(oct.buffer(), 0, length_);
+	return(true);
+}
+
+OCTSTR MfSCTPAuth::init(OCTSTR cp, const PObjectList &a) const {
+	HMAC_CTX *ctx = cp != 0 ? (HMAC_CTX *)cp : new HMAC_CTX;
+	bool ok = true;
+	CSTR work = 0;
+	OCTSTR key = 0;
+	PvOctets oct;
+	uint32_t keylen = 0;
+
+	keylen = a[1]->length();
+	keylen = (keylen + 1) / 2;
+	work = a[1]->strValue(ok);
+	oct.set(keylen);
+	key = oct.buffer();
+
+	hex_pton(key, keylen, work, a[1]->length());
+
+	if (length_ == SCTP_SHA1_SIG_SIZE) {
+	HMAC_Init(ctx, (OCTSTR)key, keylen, EVP_sha1());
+#if defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER >= 0x0090800fL)
+	} else if (length_ == SCTP_SHA256_SIG_SIZE) {
+		HMAC_Init(ctx, (OCTSTR)key, keylen, EVP_sha256());
+#endif
+	}
+
+	return((OCTSTR)ctx);
+}
+
+void MfSCTPAuth::update(OCTSTR cp, const PObjectList &a, const OCTBUF &s) const {
+	HMAC_CTX *ctx = (HMAC_CTX *)cp;
+	HMAC_Update(ctx, (OCTSTR)s.string(), s.length());
+}
+
+PvOctets *MfSCTPAuth::result(OCTSTR cp, const PObjectList &) const {
+	HMAC_CTX *ctx = (HMAC_CTX *)cp;
+	uint32_t len = HMAC_MAX_MD_CBLOCK;
+	octet m[HMAC_MAX_MD_CBLOCK];
+	PvOctets *rc = new PvOctets(length_);
+	OCTSTR os = rc->buffer();
+
+	HMAC_Final(ctx, m, &len);
+	memcpy(os, m, length_);
+	HMAC_cleanup(ctx);
+
+	return(rc);
+}
+
+PObject *MfSCTPAuth::tokenObject(int l, CSTR f) const {
+	return(new PfSCTPAuth(this, f, l));
+}
+
+bool MfSCTPAuth::hex_pton(OCTSTR dst, uint32_t dstlen, CSTR src, uint32_t srclen) const {
+	bool upper = true;
+	const char xdigits_l[] = "0123456789abcdef", xdigits_u[] = "0123456789ABCDEF", *xdigits = 0;
+	uint32_t x = 0, y = 0;
+
+	memset(dst, 0, dstlen);
+
+	for(x = 0, y = 0; ((x < srclen) && (y < dstlen)); x++) {
+		const char *cptr = 0;
+
+		if((cptr = strchr((xdigits = xdigits_l), src[x])) == 0) {
+			if((cptr = strchr((xdigits = xdigits_u), src[x])) == 0) {
+				return false;
+			}
+		}
+
+		if(upper) {
+			dst[y] = (cptr - xdigits) << 4;
+			upper = false;
+		} else {
+			dst[y] |= (cptr - xdigits);
+			upper = true;
+			y++;
+		}
+	}
+
+	return true;
+}
+
+bool MfSCTPAuth::isHexStr(CSTR buf, uint32_t buflen) const {
+	uint32_t d = 0;
+
+	for(d = 0; d < buflen; d++) {
+		if((buf[d] < '0') || (buf[d] > '9') &&
+		   (buf[d] < 'A') || (buf[d] > 'F') &&
+		   (buf[d] < 'a') || (buf[d] > 'f')) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+#undef SCTP_SHA1_SIG_SIZE
+#undef SCTP_SHA256_SIG_SIZE
 
 //======================================================================
 MvSubstr::MvSubstr(CSTR s):MvOctets(s) {}

--- a/lib/Pz/MvFunction.h
+++ b/lib/Pz/MvFunction.h
@@ -378,6 +378,27 @@ class MfDHCPAuth: public MvOctets {
 inline int32_t MfDHCPAuth::token() const {return metaToken(tkn_dhcpauthfunc_);}
 
 //======================================================================
+class MfSCTPAuth: public MvOctets {
+private:
+static uint32_t length_;
+public:
+	MfSCTPAuth(CSTR);
+virtual ~MfSCTPAuth();
+
+virtual bool generateOctetsWith(const PObjectList &, PvOctets &, WObject *) const;
+virtual uint32_t functionLength(const PObjectList &, const WObject *) const;
+virtual bool checkArgument(const PFunction &, const PObjectList &) const;
+virtual PObject *tokenObject(int, CSTR) const;
+
+virtual OCTSTR init(OCTSTR, const PObjectList &) const;
+virtual void update(OCTSTR, const PObjectList &, const OCTBUF &) const;
+virtual PvOctets *result(OCTSTR, const PObjectList &) const;
+
+virtual bool hex_pton(OCTSTR, uint32_t, CSTR, uint32_t) const;
+virtual bool isHexStr(CSTR, uint32_t) const;
+};
+
+//======================================================================
 class MvSubstr:public MvOctets {
 public:
 	MvSubstr(CSTR);

--- a/lib/Pz/PControl.cc
+++ b/lib/Pz/PControl.cc
@@ -127,6 +127,14 @@ void Con_IPinfo::generate_postDHCPAuth(WControl &c, OCTBUF &buf, WObject *up) {
 	return;
 }
 
+void Con_IPinfo::generate_postSCTPAuth(WControl &c, OCTBUF &buf, WObject *up) {
+	if(postSCTPAuth_) {
+		postSCTPAuth_->post_generate(*this, c, buf, up);
+	}
+
+	return;
+}
+
 void Con_IPinfo::print(){
 	#define PRCR	printf("\n")
 	printf("== IPinfo == "); PRCR;

--- a/lib/Pz/PControl.h
+++ b/lib/Pz/PControl.h
@@ -124,10 +124,12 @@ class Con_IPinfo{
 	TObject*	postBSA_;
 	TObject	*postP2_HASH_2_;
 	TObject*	postDHCPAuth_;
+	TObject*	postSCTPAuth_;
 public:
 	Con_IPinfo():
 		SrcAddr_(0),DstAddr_(0),LastDstAddr_(0),Route_isLeft_(false),
-		postIPChecksum_(0),postAHICV_(0),postUppChecksum_(0),postBSA_(0), postP2_HASH_2_(0), postDHCPAuth_(0) {}
+		postIPChecksum_(0),postAHICV_(0),postUppChecksum_(0),postBSA_(0), 
+		postP2_HASH_2_(0), postDHCPAuth_(0), postSCTPAuth_(0) {}
 	~Con_IPinfo(){}
 public:
 	void		SrcAddr(const PvObject* v){SrcAddr_=v;}
@@ -167,12 +169,16 @@ public:
 	void		postDHCPAuth(TObject *t) {postDHCPAuth_ = t; return;}
 	TObject*	postDHCPAuth() const {return(postDHCPAuth_);}
 
+	void		postSCTPAuth(TObject *t) {postSCTPAuth_ = t; return;}
+	TObject*	postSCTPAuth() const {return(postSCTPAuth_);}
+
 	void		reverse_postBSA(RControl&,RObject* up);
 	void		reverse_postP2_HASH_2(RControl &, RObject *);
 	void		reverse_postDHCPAuth(RControl &, RObject *);
 	void		generate_postBSA(WControl&,OCTBUF&,WObject* up);
 	void		generate_postP2_HASH_2(WControl &, OCTBUF &, WObject *);
 	void		generate_postDHCPAuth(WControl &, OCTBUF &, WObject *);
+	void		generate_postSCTPAuth(WControl &, OCTBUF &, WObject *);
 //
 	void		print();
 };

--- a/lib/pkt/LxLexer.cc
+++ b/lib/pkt/LxLexer.cc
@@ -225,6 +225,7 @@ void LxLexer::initialize() {
 	// binding security association
 	function(new MfBSA("bsa"));
 	function(new MfDHCPAuth("dhcpauth"));
+	function(new MfSCTPAuth("sctpauth"));
 	//--------------------------------------------------------------
 	// ADDRESS GENERATION(length depend on function)
 	// call functions to resolve presentation to network

--- a/script/pmod/V6evalTool/V6evalTool.pm
+++ b/script/pmod/V6evalTool/V6evalTool.pm
@@ -1058,7 +1058,7 @@ vRemote($;$@)
 		prOut("$_") if $VLog == 0;
 	}
 	close(PIN);
-	while($ChildPid == 0){};
+	while($ChildPid == 0){ checkChild(); };
 	my $status = getChildStatus();
 	prErrExit("Unknown child died $pid $ChildPid (status=$status)!!") if($ChildPid != $pid);
 	if($status & 0xff) { # died by signal
@@ -2380,7 +2380,7 @@ execCmd($;$)
 		}
     	}
 	close(PIN);
-	while($ChildPid == 0){};
+	while($ChildPid == 0){ checkChild(); };
 	my $status = getChildStatus();
 	prErrExit("Unknown child died $pid $ChildPid (status=$status)!!") if($ChildPid != $pid);
 	if( $status & 0xff ) {	# died by signal
@@ -2789,7 +2789,7 @@ BEGIN
 				# such as cpp/pkt{send,recv,ctl}
 	$InternalErr=64;        # exit code
 	# Set SIGCHLD handler to check pktbuf died while testing
-	$SIG{CHLD} = \&checkChild;
+	# $SIG{CHLD} = \&checkChild;
 	$SIG{TERM} = sub {exit;};	# This is the time to die !!
 					# explicit exit here to avoid 
 					# printing 'Terminated' message 


### PR DESCRIPTION
This patch is a backport for the git@github.com:weiyj/v6eval-3.3.2-linux.git commit:
commit b40e31a6f7dd486d49490940976c9e63774a16e3
Author: Wei Yongjun <weiyj.lk@gmail.com>
Date:   Wed Apr 29 04:27:51 2009 -0400

    sctp: implement encode for SCTP Authenticated Chunks

    This patch implement encode for SCTP Authenticated Chunks. Support
    algorithm SHA-1 and SHA-256, usage sctpauth("sha1", hexstr) or
    sctpauth("sha256", hexstr).

    Signed-off-by: Wei Yongjun <weiyj.lk@gmail.com>

Signed-off-by: Ji Jianwen <jijianwen@gmail.com>